### PR TITLE
Support delivery of packages with the same refid

### DIFF
--- a/src/validate.py
+++ b/src/validate.py
@@ -303,6 +303,10 @@ class Validator(object):
                     'DataType': 'String',
                     'StringValue': self.package_id
                 },
+                'source_filename': {
+                    'DataType': 'String',
+                    'StringValue': self.source_filename
+                },
                 'service': {
                     'DataType': 'String',
                     'StringValue': self.service_name,
@@ -329,6 +333,14 @@ class Validator(object):
                 'refid': {
                     'DataType': 'String',
                     'StringValue': self.refid,
+                },
+                'package_id': {
+                    'DataType': 'String',
+                    'StringValue': self.package_id
+                },
+                'source_filename': {
+                    'DataType': 'String',
+                    'StringValue': self.source_filename
                 },
                 'service': {
                     'DataType': 'String',

--- a/src/validate.py
+++ b/src/validate.py
@@ -106,16 +106,11 @@ class Validator(object):
         """
         downloaded_path = Path(self.tmp_dir, self.source_filename)
         client = self.get_client_with_role('s3', self.s3_role_arn)
-        transfer_config = boto3.s3.transfer.TransferConfig(
-            multipart_threshold=1024 * 25,
-            max_concurrency=10,
-            multipart_chunksize=1024 * 25,
-            use_threads=True)
+        Path(downloaded_path).parent.mkdir(parents=True, exist_ok=True)
         client.download_file(
             self.source_bucket,
             self.source_filename,
-            downloaded_path,
-            Config=transfer_config)
+            downloaded_path)
         logging.debug(f'Package downloaded to {downloaded_path}.')
         return downloaded_path
 

--- a/src/validate.py
+++ b/src/validate.py
@@ -5,6 +5,7 @@ import tarfile
 import traceback
 from pathlib import Path
 from shutil import rmtree
+from uuid import uuid4
 
 import bagit
 import boto3
@@ -56,6 +57,7 @@ class Validator(object):
         self.destination_bucket = destination_bucket
         self.source_filename = source_filename
         self.refid = Path(source_filename).stem.split('.')[0]
+        self.package_id = str(uuid4())
         self.tmp_dir = tmp_dir
         self.sns_topic = sns_topic
         self.service_name = 'digitized_image_validation'
@@ -243,15 +245,14 @@ class Validator(object):
             bag_path (pathlib.Path): path of bagit Bag containing assets.
         """
         client = self.get_client_with_role('s3', self.s3_role_arn)
-        existing = bool(client.list_objects_v2(Bucket=self.destination_bucket, Prefix=self.refid, MaxKeys=1)['KeyCount'])
+        existing = bool(client.list_objects_v2(Bucket=self.destination_bucket, Prefix=self.package_id, MaxKeys=1)['KeyCount'])
         if existing:
-            raise AlreadyExistsError(
-                f'A package with refid {self.refid} is already waiting to be QCed.')
+            self.package_id = str(uuid4())
 
         for dirpath, _, files in (bag_path / 'data').walk():
             for f in files:
                 source = dirpath / f
-                destination = Path(self.refid, source.relative_to(bag_path / 'data'))
+                destination = Path(self.package_id, source.relative_to(bag_path / 'data'))
                 file_mime_type = 'application/octet-stream'
                 suffix = Path(f).suffix
                 if suffix == '.pdf':
@@ -297,6 +298,10 @@ class Validator(object):
                 'refid': {
                     'DataType': 'String',
                     'StringValue': self.refid,
+                },
+                'package_id': {
+                    'DataType': 'String',
+                    'StringValue': self.package_id
                 },
                 'service': {
                     'DataType': 'String',

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -21,7 +21,7 @@ ARGS = [
     'digitized-image-validation-sns-role-arn',
     'source_bucket',
     'destination_bucket',
-    'b90862f3baceaae3b7418c78f9d50d52.tar.gz',
+    'R898/b90862f3baceaae3b7418c78f9d50d52.tar.gz',
     '/validation',
     'topic']
 
@@ -44,7 +44,7 @@ def test_init():
     validator = Validator(*ARGS)
     assert validator.source_bucket == 'source_bucket'
     assert validator.destination_bucket == 'destination_bucket'
-    assert validator.source_filename == 'b90862f3baceaae3b7418c78f9d50d52.tar.gz'
+    assert validator.source_filename == 'R898/b90862f3baceaae3b7418c78f9d50d52.tar.gz'
     assert validator.tmp_dir == '/validation'
     assert validator.refid == 'b90862f3baceaae3b7418c78f9d50d52'
 
@@ -136,6 +136,7 @@ def test_extract_bag():
         "fixtures",
         "b90862f3baceaae3b7418c78f9d50d52.tar.gz")
     tmp_path = Path(validator.tmp_dir, validator.source_filename)
+    tmp_path.parent.mkdir(parents=True, exist_ok=True)
     copyfile(fixture_path, tmp_path)
 
     validator.extract_bag(tmp_path)
@@ -363,7 +364,7 @@ def test_cleanup_binaries():
     assert not tmp_path.is_dir()
     found = s3.list_objects_v2(
         Bucket=validator.source_bucket,
-        Prefix=validator.refid)['KeyCount']
+        Prefix=validator.source_filename)['KeyCount']
     assert found == 1
     found = s3.list_objects_v2(
         Bucket=validator.destination_bucket,

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -380,6 +380,8 @@ def test_deliver_success_notification(mock_role):
     message_body = json.loads(messages[0].body)
     assert message_body['MessageAttributes']['outcome']['Value'] == 'SUCCESS'
     assert message_body['MessageAttributes']['refid']['Value'] == validator.refid
+    assert message_body['MessageAttributes']['package_id']['Value'] == validator.package_id
+    assert message_body['MessageAttributes']['source_filename']['Value'] == validator.source_filename
 
 
 @mock_aws
@@ -411,5 +413,7 @@ def test_deliver_failure_notification(mock_traceback, mock_role):
     message_body = json.loads(messages[0].body)
     assert message_body['MessageAttributes']['outcome']['Value'] == 'FAILURE'
     assert message_body['MessageAttributes']['refid']['Value'] == validator.refid
+    assert message_body['MessageAttributes']['package_id']['Value'] == validator.package_id
+    assert message_body['MessageAttributes']['source_filename']['Value'] == validator.source_filename
     assert exception_message in message_body['MessageAttributes']['message']['Value']
     assert message_body['MessageAttributes']['traceback']['Value'] == 'baz'

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -11,9 +11,8 @@ from moto import mock_aws
 from moto.core import DEFAULT_ACCOUNT_ID
 from PIL import UnidentifiedImageError
 
-from src.validate import (AlreadyExistsError, AssetValidationError,
-                          FileFormatValidationError, OCRError, RefidError,
-                          Validator)
+from src.validate import (AssetValidationError, FileFormatValidationError,
+                          OCRError, RefidError, Validator)
 
 ARGS = [
     'us-east-1',
@@ -290,33 +289,17 @@ def test_move_to_destination():
 
     validator.move_to_destination(tmp_path)
     expected_paths = [
-        f"{validator.refid}/master/{validator.refid}_0001.tif",
-        f"{validator.refid}/master/{validator.refid}_0002.tif",
-        f"{validator.refid}/master_edited/{validator.refid}_0001.tif",
-        f"{validator.refid}/master_edited/{validator.refid}_0002.tif",
-        f"{validator.refid}/service_edited/{validator.refid}.pdf",
+        f"{validator.package_id}/master/{validator.refid}_0001.tif",
+        f"{validator.package_id}/master/{validator.refid}_0002.tif",
+        f"{validator.package_id}/master_edited/{validator.refid}_0001.tif",
+        f"{validator.package_id}/master_edited/{validator.refid}_0002.tif",
+        f"{validator.package_id}/service_edited/{validator.refid}.pdf",
     ]
     found = s3.list_objects_v2(
         Bucket=validator.destination_bucket,
-        Prefix=validator.refid)['Contents']
+        Prefix=validator.package_id)['Contents']
     assert len(expected_paths) == len(found)
     assert sorted(expected_paths) == sorted([i['Key'] for i in found])
-
-
-@mock_aws
-def test_move_to_destination_with_exception():
-    """Asserts correct exception is raised by validator."""
-    validator = Validator(*ARGS)
-    s3 = boto3.client('s3', region_name='us-east-1')
-    s3.create_bucket(Bucket=validator.destination_bucket)
-    s3.put_object(
-        Bucket=validator.destination_bucket,
-        Key=f'{validator.refid}/this-is-a-file.txt',
-        Body='')
-
-    tmp_path = Path(validator.tmp_dir, validator.refid)
-    with pytest.raises(AlreadyExistsError):
-        validator.move_to_destination(tmp_path)
 
 
 @mock_aws


### PR DESCRIPTION
Supports validation of duplicates delivered in nested structures:
- parses refid from source filename
- mints a UUID for package and saves it to QC bucket using that filepath
- sends original source filename and new package ID along with refid in messages